### PR TITLE
Extended list of HTML file extensions with shtml

### DIFF
--- a/html.behaviors
+++ b/html.behaviors
@@ -1,4 +1,4 @@
 {:+ {:app [(:lt.objs.plugins/load-js ["codemirror/htmlmixed.js" "codemirror/htmlembedded.js" "html_compiled.js"])]
      :editor.html [:lt.plugins.html/eval-on-save :lt.plugins.html/on-eval (:lt.objs.editor/tab-settings false 4 4)]
-     :files [(:lt.objs.files/file-types [{:name "HTML" :exts [:html :htm] :mime "htmlmixed" :tags [:editor.html]}])]
+     :files [(:lt.objs.files/file-types [{:name "HTML" :exts [:html :htm :shtml] :mime "htmlmixed" :tags [:editor.html]}])]
      :html.lang [:lt.plugins.html/eval!]}}


### PR DESCRIPTION
Extended list of HTML file extensions with shtml, so higlighting and, more important, eval works without setting language manually each time.
