### PR TITLE
Changed eval-on-save function to handle external browser connections.

### DIFF
--- a/src/lt/plugins/html.cljs
+++ b/src/lt/plugins/html.cljs
@@ -23,11 +23,12 @@
 (behavior ::eval-on-save
           :triggers #{:save}
           :reaction (fn [editor]
-                      (when (and (-> @editor :client :default)
-                                 (not (clients/placeholder? (-> @editor :client :default))))
-                        (object/raise html-lang :eval! {:origin editor
-                                                        :info (assoc (@editor :info)
-                                                                :code (ed/->val (:ed @editor)))}))))
+                      (when-let [default (-> @editor :client :default)]
+                        (if (or (not @default) (not (clients/placeholder? default)))
+                          (object/raise html-lang :eval!
+                                        {:origin editor
+                                         :info (assoc (@editor :info)
+                                                 :code (ed/->val (:ed @editor)))})))))
 
 (behavior ::eval!
           :triggers #{:eval!}


### PR DESCRIPTION
Had the same problem as detailed here in [LightTable issue #1309](https://github.com/LightTable/LightTable/issues/1309) and found the default editor is `#<Atom: nil>` when connected to an external browser. So far this fix has worked for me.

Thoughts?
